### PR TITLE
Add permissions.query to `__proto__` to fool `hasOwnProperty`

### DIFF
--- a/apply-evasions.js
+++ b/apply-evasions.js
@@ -27,11 +27,12 @@ module.exports = async function(page) {
   // Pass the Permissions Test.
   await page.evaluateOnNewDocument(() => {
     const originalQuery = window.navigator.permissions.query;
-    window.navigator.permissions.query = parameters =>
+    window.navigator.permissions.__proto__.query = parameters =>
       parameters.name === 'notifications'
         ? Promise.resolve({state: Notification.permission})
         : originalQuery(parameters);
-    window.navigator.permissions.query.toString = _ => 'function query() { [native code] }';
+    window.navigator.permissions.__proto__.query.toString = _ =>
+      'function query() { [native code] }';
   });
 
   // Pass the Plugins Length Test.

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Let's host this [fight](https://news.ycombinator.com/item?id=16179602) within a 
 
 **Current status:**
 ```txt
-Headless detection *succeeded*.
-🔍  Detectors are winning!
+Headless detection *failed*.
+😎  Evaders are winning!
 ```
 
 ---------------


### PR DESCRIPTION
Simple fix to fool `hasOwnProperty`. Still can still be detected by the method described in #1.
> This would still leak the function overwrite because window.navigator.permissions.query.toString.toString() would evaluate to _ => 'function query() { [native code] }' instead of function toString() { [native code] }.
See: http://jsbin.com/vokoboloqu/1/edit?js,console