### PR TITLE
Circumvent to toString

### DIFF
--- a/apply-evasions.js
+++ b/apply-evasions.js
@@ -31,8 +31,15 @@ module.exports = async function(page) {
       parameters.name === 'notifications'
         ? Promise.resolve({state: Notification.permission})
         : originalQuery(parameters);
-    window.navigator.permissions.__proto__.query.toString = _ =>
-      'function query() { [native code] }';
+    window.navigator.permissions.__proto__.query.toString = new Proxy(originalQuery.toString, {
+      get() {
+        return originalQuery.toString.bind(originalQuery.toString);
+      },
+      
+      apply() {
+        return 'function query() { [native code] }';
+      }
+    })
   });
 
   // Pass the Plugins Length Test.

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Let's host this [fight](https://news.ycombinator.com/item?id=16179602) within a 
 
 **Current status:**
 ```txt
-Headless detection *succeeded*.
-🔍  Detectors are winning!
+Headless detection *failed*.
+😎  Evaders are winning!
 ```
 
 ---------------


### PR DESCRIPTION
Use proxy to wrap the original toString method and do different things on `apply` and `get` to get original output. 

This can definitely be detected but I am done for today. 