### PR TITLE
Detect proxy object

### DIFF
--- a/detect-headless.js
+++ b/detect-headless.js
@@ -31,6 +31,11 @@ module.exports = async function() {
     const permissions = window.navigator.permissions;
     if (permissions.query.toString() !== 'function query() { [native code] }') return true;
     if (permissions.query.toString.toString() !== 'function toString() { [native code] }') return true;
+    if (
+      permissions.query.toString.hasOwnProperty('[[Handler]]') &&
+      permissions.query.toString.hasOwnProperty('[[Target]]') &&
+      permissions.query.toString.hasOwnProperty('[[IsRevoked]]')
+    ) return true;
     if (permissions.hasOwnProperty('query')) return true;
   });
 

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Let's host this [fight](https://news.ycombinator.com/item?id=16179602) within a 
 
 **Current status:**
 ```txt
-Headless detection *failed*.
-😎  Evaders are winning!
+Headless detection *succeeded*.
+🔍  Detectors are winning!
 ```
 
 ---------------


### PR DESCRIPTION
This was trickery than I thought and should not even be possible. As described [here](http://2ality.com/2014/12/es6-proxies.html#transparent-virtualization-and-handler-encapsulation) proxies should achieve transparent virtualization but it looks like chrome is leaking the implementation via three properties (`[[Handler]]`, `[[Target]]` and `[[IsRevoked]]`). 

Detectors are winning again! 