### PR TITLE
Iframe detection

### DIFF
--- a/detect-headless.js
+++ b/detect-headless.js
@@ -42,5 +42,15 @@ module.exports = async function() {
     return navigator.languages === '';
   });
 
+  await test('iFrame for fresh window object', _ => {
+    const iframe = document.createElement('iframe');
+    iframe.srcdoc = 'about:blank';  
+    document.body.appendChild(iframe);
+
+    // Here we would need to rerun all tests with `iframe.contentWindow` as `window`
+    // Example:
+    return iframe.contentWindow.navigator.plugins.length === 0
+  });
+
   return results;
 };

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Let's host this [fight](https://news.ycombinator.com/item?id=16179602) within a 
 
 **Current status:**
 ```txt
-Headless detection *failed*.
-😎  Evaders are winning!
+Headless detection *succeeded*.
+🔍  Detectors are winning!
 ```
 
 ---------------


### PR DESCRIPTION
This is a tricky detection. We can use an iframe to get a fresh `window` object and use that to potential rerun all the tests we did on the first `window` object. 

I mocked the tests for this to show how it would go. The `apply-evasion` script should be injected into each JS context and not only the first one. 