### PR TITLE
Detect Chrome headless using webdriver

### DIFF
--- a/apply-evasions.js
+++ b/apply-evasions.js
@@ -74,10 +74,17 @@ module.exports = async function(page) {
 
   // Pass the iframe Test
   await page.evaluateOnNewDocument(() => {
-      Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
-          get: function() {
-            return window;
-          }
-      });
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+      get: function() {
+        return window;
+      }
+    });
+  });
+
+  // Pass toString test
+  await page.evaluateOnNewDocument(() => {
+    window.console.debug = () => {
+      return null;
+    };
   });
 };

--- a/apply-evasions.js
+++ b/apply-evasions.js
@@ -81,7 +81,7 @@ module.exports = async function(page) {
     });
   });
 
-  // Pass toString test
+  // Pass toString test, though it breaks console.debug() from working
   await page.evaluateOnNewDocument(() => {
     window.console.debug = () => {
       return null;

--- a/detect-headless.js
+++ b/detect-headless.js
@@ -17,7 +17,7 @@ module.exports = async function() {
   // Detects the --enable-automation || --headless flags
   // Will return true in headful if --enable-automation is provided
   await test('navigator.webdriver present', _ => {
-    return navigator.webdriver;
+    return 'webdriver' in navigator;
   });
 
   await test('window.chrome missing', _ => {


### PR DESCRIPTION
Instead of testing if webdriver is true we test for its presence using the *in* operator.
It would also work with *hasOwnProperty*.